### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,8 @@
 name: Build&Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/aagsolutions/nbis/security/code-scanning/2](https://github.com/aagsolutions/nbis/security/code-scanning/2)

To fix the problem, we should introduce a `permissions` block to minimize the privileges given to the workflow. Since this workflow only checks out code, sets up Java, sets up Gradle, and runs a build and test command, it does not require write access to the repo, issues, or pull requests. Therefore, `contents: read` is the recommended minimal permission set. The `permissions` key can be added at the workflow level (above jobs:), so it applies to all jobs unless overridden. To fix, add the following block after the `name:` and before or after the `on:` definition in `.github/workflows/main.yml`:

```yaml
permissions:
  contents: read
```

No additional imports, method definitions, or other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
