### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,6 @@
 name: Publish
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/aagsolutions/nbis/security/code-scanning/3](https://github.com/aagsolutions/nbis/security/code-scanning/3)

To address this issue, add the `permissions` block to restrict the GitHub Actions job or workflow to the minimum necessary privileges. Since the workflow does not use any write operations on GitHub itself (such as modifying content, creating issues, etc.) and just runs local build/publish tasks, `contents: read` is appropriate. You should add:

- A `permissions:` block at the top (root) level, just after `name:` and before `on:`, OR at the job level under the relevant job (here, `build:`).
- For maintainability and clarity, adding the `permissions` key at the top/root level ensures all jobs receive these permissions by default.
- Minimal `permissions` block:
  ```yaml
  permissions:
    contents: read
  ```
- Place this block after `name: Publish` and before `on:`.
- No new imports or method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
