### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on: workflow_dispatch
 
 jobs:
   build:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources


### PR DESCRIPTION
Potential fix for [https://github.com/aagsolutions/nbis/security/code-scanning/1](https://github.com/aagsolutions/nbis/security/code-scanning/1)

The best way to fix this issue is to explicitly specify the `permissions` block in the workflow YAML file. For this release workflow, we should start with the minimal permissions required. Since releases may require write access to repository contents (such as pushing tags, modifying release assets, etc.), but unless the workflow specifically requires write permissions (e.g., for PRs, issues, etc.), we can give only the required permissions. According to best practice, start by setting `contents: write` at either the workflow or job level depending on which scope the actions need these permissions. If more granular permissions (such as `pull-requests: write`) are necessary for some actions, those can be added as needed.

For this workflow, the `permissions` block should be added at the job level (right under `jobs.build:`), granting only the required access. Based on the given steps—checkout, setup, and a Gradle release command which often pushes commits/tags—we should provide `contents: write`. If that's not enough, further permissions can be added later, but it's the safest minimum.

Edit the `.github/workflows/release.yml` file by adding:
```
    permissions:
      contents: write
```
immediately after `jobs:`, aligned with the job definition. No external dependencies or imports are required for this fix.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
